### PR TITLE
Timer hotfix

### DIFF
--- a/src/Protocol/AbstractProtocol.php
+++ b/src/Protocol/AbstractProtocol.php
@@ -76,7 +76,7 @@ abstract class AbstractProtocol implements ProtocolInterface {
     public function onHeartbeat(){
 
         if(isset($this->heartbeat_timer)){
-            $this->heartbeat_timer->cancel();
+            $this->client->getLoop()->cancelTimer($this->heartbeat_timer);
         }
 
         $this->startHeartbeat();


### PR DESCRIPTION
$timer->cancel now deprecated in reactphp/event-loop v0.5

Apologies missed this in previous PR